### PR TITLE
Fix compatibility with vscode-saltstack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,17 @@
 		"url": "https://github.com/warpnet/vscode-salt-lint.git"
 	},
 	"activationEvents": [
-		"onLanguage:saltstack"
+		"onLanguage:sls"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
 		"languages": [
             {
-                "id": "saltstack",
+                "id": "sls",
                 "aliases": [
                     "SaltStack",
-                    "salt"
+                    "salt",
+                    "pillar"
                 ],
                 "extensions": [
                     ".sls"

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -69,7 +69,7 @@ function substitutePath(s: string): string {
 
 export default class SaltLintProvider implements vscode.CodeActionProvider {
 
-    public static LANGUAGE_ID = 'saltstack';
+    public static LANGUAGE_ID = 'sls';
     private channel: vscode.OutputChannel;
     private settings!: SaltLintSettings;
     private executableNotFound: boolean;


### PR DESCRIPTION
Fix compatibility with [vscode-saltstack](https://github.com/korekontrol/vscode-saltstack) by updating the language ID to `sls`, the ID that [vscode-saltstack](https://github.com/korekontrol/vscode-saltstack) is using.

Fixes #3.