### PR TITLE
Change Buffer() to Buffer.from()

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -253,8 +253,8 @@ export default class SaltLintProvider implements vscode.CodeActionProvider {
 
                 const output: string[] = [];
                 childProcess.stdout
-                    .on('data', (data: Buffer) => {
-                        output.push(data.toString());
+                    .on('data', (data) => {
+                        output.push(Buffer.from(data).toString());
                     })
                     .on('end', () => {
                         let diagnostics: vscode.Diagnostic[] = [];


### PR DESCRIPTION
Change `Buffer()` to `Buffer.from()` to remove deprecation warning `DEP0005`. For more information see:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Fixes #2.