### PR TITLE
Fix double registered property with shellcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
           "scope": "resource",
           "default": "salt-lint"
         },
-        "shellcheck.run": {
+        "salt-lint.run": {
           "description": "Whether salt-lint is run on save or on type.",
           "type": "string",
           "enum": [


### PR DESCRIPTION
Fix double registered property when `vscode-salt-lint` is installed in combination with `shellcheck`.

Fixes #11 